### PR TITLE
fix(release): undesired release behavior

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ out
 dist
 .vscode-test
 test-resources
+CHANGELOG.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^9.0.3",
+        "@semantic-release/npm": "^10.0.4",
         "@semantic-release/release-notes-generator": "^11.0.3",
         "@types/debug": "^4.1.8",
         "@types/glob": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "displayName": "ESP8266/ESP32 Exception Decoder Extension for the Arduino IDE",
   "description": "Arduino IDE extension lets you get a more meaningful explanation of the stack traces and backtraces you get on ESP8266/ESP32",
   "version": "0.1.0",
+  "private": true,
   "engines": {
     "vscode": "^1.78.0"
   },
@@ -62,6 +63,7 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^9.0.3",
+    "@semantic-release/npm": "^10.0.4",
     "@semantic-release/release-notes-generator": "^11.0.3",
     "@types/debug": "^4.1.8",
     "@types/glob": "^8.1.0",

--- a/release.config.js
+++ b/release.config.js
@@ -3,11 +3,13 @@
 
 /** @type {import('semantic-release').Options} */
 module.exports = {
+  tagFormat: '${version}',
   branches: ['main'],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
+    '@semantic-release/npm',
     [
       '@semantic-release/github',
       {
@@ -22,6 +24,7 @@ module.exports = {
     [
       'semantic-release-vsce',
       {
+        packageVsix: true, // It's default to true when OVSX_PAT env is set
         publish: false, // Do not publish to VS Code Marketplace, but to Open VSX
       },
     ],
@@ -29,7 +32,7 @@ module.exports = {
       '@semantic-release/exec',
       {
         publishCmd:
-          'echo "::set-output name=release_version::${nextRelease.version}"',
+          'echo "release_version=${nextRelease.version}" >> $GITHUB_OUTPUT',
       },
     ],
   ],


### PR DESCRIPTION
 - remove `v` from the tag name,
 - explicit VSIX packaging (it's true by default),
 - remove `set-output` warning in GH Actions,
 - auto update version in `package.json`,
 - disable prettier in the changelog