### PR TITLE
fix: use vscode.Uri when building readonly fs path

### DIFF
--- a/src/capturer/fsProviders.ts
+++ b/src/capturer/fsProviders.ts
@@ -57,14 +57,17 @@ export class CrashReportContentProvider
 export function toReadonlyLibraryUri(filePath: string): vscode.Uri {
   return vscode.Uri.from({
     scheme: readonlyLibraryScheme,
-    path: filePath.replace(/\\/g, '/'),
+    path: vscode.Uri.file(filePath).path,
     query: `source=${encodeURIComponent(filePath)}`,
   })
 }
 
 export function toSourcePathFromReadonlyUri(uri: vscode.Uri): string {
   const source = new URLSearchParams(uri.query).get('source')
-  return source && source.length > 0 ? source : uri.path
+  if (source && source.length > 0) {
+    return source
+  }
+  return /^\/[A-Za-z]:\//.test(uri.path) ? uri.path.slice(1) : uri.path
 }
 
 export class ReadonlyFsProvider

--- a/src/test/suite/fsProviders.test.ts
+++ b/src/test/suite/fsProviders.test.ts
@@ -54,6 +54,26 @@ describe('fsProviders', () => {
     assert.equal(toSourcePathFromReadonlyUri(fallback), '/tmp/no-query.cpp')
   })
 
+  it('creates absolute readonly uris for Windows drive-letter paths', () => {
+    const sourcePath =
+      'C:\\Users\\xxx\\AppData\\Local\\Arduino15\\packages\\esp32\\hardware\\esp32\\3.2.1\\cores\\esp32\\main.cpp'
+    const uri = toReadonlyLibraryUri(sourcePath)
+    const serialized = uri.toString()
+
+    assert.equal(uri.scheme, readonlyLibraryScheme)
+    assert.equal(toSourcePathFromReadonlyUri(uri), sourcePath)
+    assert.equal(serialized.startsWith(`${readonlyLibraryScheme}:/`), true)
+
+    const fallback = vscode.Uri.from({
+      scheme: readonlyLibraryScheme,
+      path: '/C:/Users/xxx/AppData/Local/Arduino15/main.cpp',
+    })
+    assert.equal(
+      toSourcePathFromReadonlyUri(fallback),
+      'C:/Users/xxx/AppData/Local/Arduino15/main.cpp'
+    )
+  })
+
   it('reads readonly files and blocks write operations', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'capturer-fs-'))
     const subDir = path.join(root, 'sub')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
-//@ts-check
+// @ts-check
 'use strict'
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path')
 
 /** @type {import('webpack').Configuration} */


### PR DESCRIPTION
Closes #64